### PR TITLE
Add Fastify support

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-unused-imports": "^4.1.4",
     "express": "^4.18.1",
+    "fastify": "^4.25.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "28.1.1",
     "jest-environment-node": "^29.7.0",

--- a/packages/fastify/README.md
+++ b/packages/fastify/README.md
@@ -1,0 +1,5 @@
+# fastify
+
+Fastify integration for typesafe-api.
+
+This package provides helpers to register typesafe routes and error handling with Fastify.

--- a/packages/fastify/__ts_type_test__/request.ts
+++ b/packages/fastify/__ts_type_test__/request.ts
@@ -1,0 +1,32 @@
+import type { Controller, TRequest, TResponse } from '../src';
+import type { CreateDogEndpointDef } from 'example-api-spec';
+
+
+export const reqTest: Controller<CreateDogEndpointDef> = async (
+  req: TRequest<CreateDogEndpointDef>,
+  _res: TResponse<CreateDogEndpointDef>
+) => {
+  // Valid header
+  req.get('myheader');
+
+  // Invalid valid header
+  req.get('not-a-valid-header');
+
+  // Invalid query param
+  req.query.badQuery;
+
+  // Valid body
+  req.body.name;
+
+  // Invalid body
+  req.body.badBody;
+
+  // Invalid param
+  req.params.badParam;
+};
+
+// @expected-compiler-errors-start
+// (13,11): error TS2769: No overload matches this call.
+// (16,13): error TS2339: Property 'badQuery' does not exist on type 'never'.
+// (22,12): error TS2339: Property 'badBody' does not exist on type '{ name: string; breed: string; }'.
+// (25,14): error TS2339: Property 'badParam' does not exist on type 'never'.

--- a/packages/fastify/__ts_type_test__/response.ts
+++ b/packages/fastify/__ts_type_test__/response.ts
@@ -1,0 +1,20 @@
+import type { Controller, TRequest, TResponse } from '../src';
+import type { GetDogEndpointDef } from 'example-api-spec';
+
+
+export const reqTest: Controller<GetDogEndpointDef> = async (
+  req: TRequest<GetDogEndpointDef>,
+  res: TResponse<GetDogEndpointDef>
+) => {
+  // Invalid body supplied
+  res.send({ somethingElse: 1 });
+
+  // Valid header
+  res.set('myheader', 'hi');
+
+  // Invalid header
+  res.set('not-a-valid-header', 'hi');
+};
+
+// @expected-compiler-errors-start
+// (10,14): error TS2353: Object literal may only specify known properties, and 'somethingElse' does not exist in type 'BodyOrError<GetDogEndpointDef>'.

--- a/packages/fastify/jest.config.ts
+++ b/packages/fastify/jest.config.ts
@@ -1,0 +1,10 @@
+export default {
+  displayName: 'express',
+  preset: '../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../coverage/packages/express',
+};

--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@typesafe-api/fastify",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "tslib": "^2.3.0",
+    "fastify": "^4.25.0",
+    "@typesafe-api/core": "0.0.1",
+    "axios": "^1.7.1"
+  }
+}

--- a/packages/fastify/project.json
+++ b/packages/fastify/project.json
@@ -1,0 +1,43 @@
+{
+  "name": "fastify",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/fastify/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "generatorOptions": {
+        "packageRoot": "dist/{projectRoot}",
+        "currentVersionResolver": "git-tag",
+        "fallbackCurrentVersionResolver": "disk"
+      }
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/packages/fastify",
+        "main": "packages/fastify/src/index.ts",
+        "tsConfig": "packages/fastify/tsconfig.lib.json",
+        "assets": ["packages/fastify/*.md"]
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "packages/fastify/jest.config.ts"
+      }
+    }
+  }
+}

--- a/packages/fastify/src/index.ts
+++ b/packages/fastify/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib';

--- a/packages/fastify/src/lib/controller.ts
+++ b/packages/fastify/src/lib/controller.ts
@@ -1,0 +1,36 @@
+import type { AbstractEndpointDef, ResponseBody } from '@typesafe-api/core';
+import type { FastifyRequest, FastifyReply } from 'fastify';
+
+type ToExclude = Record<string, never>;
+
+export interface TRequest<T extends AbstractEndpointDef>
+  extends FastifyRequest<{
+    Params: Exclude<T['mergedReq']['params'], ToExclude>;
+    Body: Exclude<T['mergedReq']['body'], ToExclude>;
+    Querystring: Exclude<T['mergedReq']['query'], ToExclude>;
+    Headers: Exclude<T['mergedReq']['headers'], ToExclude>;
+  }> {}
+
+export type BodyOrError<T extends AbstractEndpointDef> =
+  | ResponseBody<T>
+  | T['errorType'];
+
+export interface TResponse<T extends AbstractEndpointDef>
+  extends FastifyReply {
+  header(
+    name: keyof T['resp']['headers'],
+    value?: string | number | string[]
+  ): this;
+}
+
+export type Controller<T extends AbstractEndpointDef> = (
+  req: TRequest<T>,
+  res: TResponse<T>
+) => Promise<void>;
+
+export const sendError = <T extends AbstractEndpointDef>(
+  res: TResponse<T>,
+  errorType: T['errorType']
+): void => {
+  res.status(errorType.statusCode).send(errorType);
+};

--- a/packages/fastify/src/lib/fastify-route.ts
+++ b/packages/fastify/src/lib/fastify-route.ts
@@ -1,0 +1,45 @@
+import type { Controller, TRequest, TResponse } from './controller';
+import type { AbstractEndpointDef, Route } from '@typesafe-api/core';
+import type {
+  FastifyInstance,
+  preHandlerHookHandler,
+  HTTPMethods,
+} from 'fastify';
+
+export interface FastifyRoute<T extends AbstractEndpointDef> extends Route<T> {
+  preHandler?: preHandlerHookHandler | preHandlerHookHandler[];
+  controller: Controller<T>;
+}
+
+export const addRoutes = (
+  f: FastifyInstance,
+  routes: FastifyRoute<AbstractEndpointDef>[]
+): void => {
+  for (const route of routes) {
+    addRoute(f, route);
+  }
+};
+
+export const addRoute = <T extends AbstractEndpointDef>(
+  f: FastifyInstance,
+  route: FastifyRoute<T>
+): void => {
+  const { method, path, controller, preHandler } = route;
+  if (!method) {
+    throw new Error('Method is required');
+  }
+  if (!path) {
+    throw new Error('Path is required');
+  }
+  if (!controller) {
+    throw new Error('Controller is required');
+  }
+
+  f.route({
+    method: method.toUpperCase() as HTTPMethods,
+    url: path,
+    preHandler,
+    handler: async (req, reply) =>
+      controller(req as TRequest<T>, reply as TResponse<T>),
+  });
+};

--- a/packages/fastify/src/lib/index.ts
+++ b/packages/fastify/src/lib/index.ts
@@ -1,0 +1,3 @@
+export * from './controller';
+export * from './fastify-route';
+export * from './middleware';

--- a/packages/fastify/src/lib/middleware/index.ts
+++ b/packages/fastify/src/lib/middleware/index.ts
@@ -1,0 +1,1 @@
+export * from './typesafe-api-errors';

--- a/packages/fastify/src/lib/middleware/typesafe-api-errors.ts
+++ b/packages/fastify/src/lib/middleware/typesafe-api-errors.ts
@@ -1,0 +1,53 @@
+import {
+  defaultHttpErrorLogFn,
+  defaultOtherErrorLogFn,
+  TypesafeHttpError,
+} from '@typesafe-api/core';
+
+import type {
+  AnyErrorType,
+  TypeSafeApiErrorsParams,
+} from '@typesafe-api/core';
+import type { FastifyReply, FastifyPluginCallback } from 'fastify';
+
+const sendError = (reply: FastifyReply, err: AnyErrorType): void => {
+  reply.status(err.statusCode).send(err.body);
+};
+
+const handleError = async <T extends AnyErrorType>(
+  params: TypeSafeApiErrorsParams<T>,
+  err: unknown,
+  reply: FastifyReply
+): Promise<void> => {
+  const {
+    httpErrorLogFn = defaultHttpErrorLogFn,
+    otherErrorLogFn = defaultOtherErrorLogFn,
+    internalServerErrorBody,
+  } = params;
+
+  if (err instanceof TypesafeHttpError) {
+    await httpErrorLogFn(err.httpError);
+    sendError(reply, err.httpError);
+    return;
+  }
+
+  await otherErrorLogFn(err);
+  sendError(reply, {
+    statusCode: 500,
+    body: internalServerErrorBody,
+  });
+};
+
+export const typesafeApiErrors = <T extends AnyErrorType>(
+  params: TypeSafeApiErrorsParams<T>
+): FastifyPluginCallback => {
+  return (fastify, _opts, done) => {
+    fastify.setErrorHandler((err, _req, reply) => {
+      handleError(params, err, reply).catch((handleErr) => {
+        console.log('typesafe-api error handling failed', handleErr);
+        console.log('The original error was', err);
+      });
+    });
+    done();
+  };
+};

--- a/packages/fastify/test/e2e.test.ts
+++ b/packages/fastify/test/e2e.test.ts
@@ -1,0 +1,162 @@
+import { handleError } from '@typesafe-api/core';
+import {
+  defaultReqOptions,
+  RootApiClient,
+  clearDogDB,
+  scoobyDoo,
+} from 'example-api-spec';
+
+import { internalServerErrorBody, startApp } from './example-fastify';
+
+import type {
+  EasyErrorBody,
+  ErrorHandlers,
+  ResponseBody,
+} from '@typesafe-api/core';
+import type { AxiosError, AxiosRequestConfig } from 'axios';
+import type {
+  GetDogEndpointDef,
+  GetDogErrorType,
+  HeaderTestEndpointDef,
+} from 'example-api-spec';
+import type { FastifyInstance } from 'fastify';
+
+export const OBJECT_ID_STRING = /^[a-f\d]{24}$/i;
+
+const defaultHeaderTestResp: ResponseBody<HeaderTestEndpointDef> = {
+  headerValue: defaultReqOptions.headers.myheader,
+};
+
+const getDogErrorHandlers: ErrorHandlers<GetDogEndpointDef> = {
+  400: jest.fn(),
+  403: jest.fn(),
+  404: jest.fn(),
+  500: jest.fn(),
+};
+
+const zeroContent: AxiosRequestConfig = { maxContentLength: 0 };
+
+const expectMaxContentSizeError = async (
+  resp: Promise<unknown>
+): Promise<void> =>
+  expect(resp).rejects.toThrow(/maxContentLength size of 0 exceeded/);
+
+let baseUrl: string;
+let server: FastifyInstance;
+let rootApiClient: RootApiClient;
+
+beforeAll(async () => {
+  const appStarted = await startApp();
+  baseUrl = appStarted.baseUrl;
+  server = appStarted.server;
+  clearDogDB();
+
+  const apiParams = { baseUrl, defaultReqOptions };
+  rootApiClient = new RootApiClient(apiParams);
+});
+
+afterAll(async () => {
+  clearDogDB();
+  await server.close();
+});
+
+it('Test Root API (headers and default params)', async () => {
+  const hitEndpont = async (
+    options: HeaderTestEndpointDef['req']
+  ): Promise<ResponseBody<HeaderTestEndpointDef>> => {
+    const resp = await rootApiClient.headerTest(options);
+    return resp.data;
+  };
+
+  // Test with no options
+  expect(await hitEndpont({})).toStrictEqual(defaultHeaderTestResp);
+
+  // Test headers object but not key-values
+  expect(await hitEndpont({ headers: {} })).toStrictEqual(
+    defaultHeaderTestResp
+  );
+
+  // Test with custom value
+  const customValue = 'custom-value';
+  const expectedCustom: ResponseBody<HeaderTestEndpointDef> = {
+    headerValue: customValue,
+  };
+  expect(
+    await hitEndpont({ headers: { myheader: customValue } })
+  ).toStrictEqual(expectedCustom);
+});
+
+it('Test response headers', async () => {
+  const resp = await rootApiClient.headerTest({});
+  expect(resp.data).toStrictEqual(defaultHeaderTestResp);
+  expect(resp.headers['test-header']).toBe(defaultHeaderTestResp.headerValue);
+});
+
+it('Test default axios config', async () => {
+  const axiosTestClient = new RootApiClient({
+    baseUrl,
+    axiosConfig: zeroContent,
+  });
+  await expectMaxContentSizeError(axiosTestClient.headerTest({}));
+});
+
+it('Test request axios config', async () => {
+  const axiosTestClient = new RootApiClient({
+    baseUrl,
+  });
+  const resp = axiosTestClient.headerTest({}, zeroContent);
+  await expectMaxContentSizeError(resp);
+});
+
+it('Dog API', async () => {
+  const dogClient = rootApiClient.dog();
+
+  // Create a dog
+  const createResp = await dogClient.createDog(scoobyDoo);
+  const respBody = createResp.data;
+  const { _id } = respBody;
+  expect(_id).toMatch(OBJECT_ID_STRING);
+  const dogWithId = {
+    ...scoobyDoo,
+    _id,
+  };
+  expect(respBody).toStrictEqual(dogWithId);
+
+  // Try to get the same dog
+  const getOneResp = await dogClient.getDog(_id);
+  expect(getOneResp.data).toStrictEqual(dogWithId);
+
+  // Get all the dogs
+  const getAllResp = await dogClient.getDogs();
+  expect(getAllResp.data).toStrictEqual([dogWithId]);
+
+  // Try to get a dog that doesn't exist
+  const fakeId = 'not-a-real-dog';
+  try {
+    await dogClient.getDog(fakeId);
+  } catch (err) {
+    // Check the error is returned as expected
+    const e = err as AxiosError<GetDogErrorType>;
+    const expectedError: EasyErrorBody = {
+      msg: `No dog with _id ${fakeId} could be found`,
+    };
+    expect(e.response?.data).toStrictEqual(expectedError);
+    expect(e.response?.status).toBe(404);
+
+    // Test handle error works correctly
+    handleError(e, getDogErrorHandlers);
+    expect(getDogErrorHandlers['404']).toBeCalled();
+    expect(getDogErrorHandlers['500']).toBeCalledTimes(0);
+  }
+});
+
+it('Test default error handling', async () => {
+  try {
+    await rootApiClient.internalErrorTest({});
+  } catch (err) {
+    // Check the error is returned as expected
+    const e = err as AxiosError<GetDogErrorType>;
+    expect(e.response?.data).toStrictEqual(internalServerErrorBody);
+    expect(e.response?.status).toBe(500);
+  }
+});

--- a/packages/fastify/test/example-controller.ts
+++ b/packages/fastify/test/example-controller.ts
@@ -1,0 +1,69 @@
+import ObjectID from 'bson-objectid';
+import { MyApiHttpError } from 'example-api-spec';
+import { dogDB } from 'example-api-spec/src/lib/dto/dog';
+
+import type { Controller, TRequest, TResponse } from '../src';
+import type {
+  CreateDogEndpointDef,
+  GetDogEndpointDef,
+  GetDogsEndpointDef,
+  HeaderTestEndpointDef,
+  InternalErrorTestEndpointDef,
+} from 'example-api-spec';
+import type { DogWithId } from 'example-api-spec/src/lib/dto/dog';
+
+export const createDogController: Controller<CreateDogEndpointDef> = async (
+  req: TRequest<CreateDogEndpointDef>,
+  res: TResponse<CreateDogEndpointDef>
+) => {
+  const _id = new ObjectID().toHexString();
+  const dogWithId: DogWithId = {
+    ...req.body,
+    _id,
+  };
+  dogDB.set(_id, dogWithId);
+  res.send(dogWithId);
+};
+
+export const getDogController: Controller<GetDogEndpointDef> = async (
+  req: TRequest<GetDogEndpointDef>,
+  res: TResponse<GetDogEndpointDef>
+) => {
+  const { _id } = req.params;
+  if (dogDB.has(_id)) {
+    res.send(dogDB.get(_id));
+  } else {
+    throw new MyApiHttpError(404, `No dog with _id ${_id} could be found`);
+  }
+};
+
+export const getDogsController: Controller<GetDogsEndpointDef> = async (
+  req: TRequest<GetDogsEndpointDef>,
+  res: TResponse<GetDogsEndpointDef>
+) => {
+  res.send(Array.from(dogDB.values()));
+};
+
+export const headerTestController: Controller<HeaderTestEndpointDef> = async (
+  req: TRequest<HeaderTestEndpointDef>,
+  res: TResponse<HeaderTestEndpointDef>
+) => {
+  const value = req.get('myheader');
+
+  if (!value) {
+    throw new Error('No value provided');
+  }
+
+  res.set('test-header', value);
+
+  res.send({ headerValue: value });
+};
+
+export const internalErrorTestController: Controller<
+  InternalErrorTestEndpointDef
+> = async (
+  _req: TRequest<InternalErrorTestEndpointDef>,
+  _res: TResponse<InternalErrorTestEndpointDef>
+) => {
+  throw Error('Example error');
+};

--- a/packages/fastify/test/example-fastify.ts
+++ b/packages/fastify/test/example-fastify.ts
@@ -1,0 +1,92 @@
+import {
+  getDogRoute,
+  getDogsRoute,
+  headerTestRoute,
+  internalErrorTestRoute,
+  postDogRoute,
+} from 'example-api-spec';
+import Fastify from 'fastify';
+import findFreePorts from 'find-free-ports';
+
+import { addRoutes } from '../src';
+import {
+  createDogController,
+  getDogController,
+  getDogsController,
+  headerTestController,
+  internalErrorTestController,
+} from './example-controller';
+import { typesafeApiErrors } from '../src/lib/middleware/typesafe-api-errors';
+
+import type { FastifyRoute } from '../src';
+import type {
+  CreateDogEndpointDef,
+  GetDogEndpointDef,
+  GetDogsEndpointDef,
+  HeaderTestEndpointDef,
+  InternalErrorTestEndpointDef,
+  MyApiDefaultErrorType,
+} from 'example-api-spec';
+import type { FastifyInstance } from 'fastify';
+
+const app = Fastify();
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const routes: FastifyRoute<any>[] = [];
+
+const fPostDogRoute: FastifyRoute<CreateDogEndpointDef> = {
+  ...postDogRoute,
+  controller: createDogController,
+};
+routes.push(fPostDogRoute);
+
+const fGetDogRoute: FastifyRoute<GetDogEndpointDef> = {
+  ...getDogRoute,
+  controller: getDogController,
+};
+routes.push(fGetDogRoute);
+
+const fGetDogsRoute: FastifyRoute<GetDogsEndpointDef> = {
+  ...getDogsRoute,
+  controller: getDogsController,
+};
+routes.push(fGetDogsRoute);
+
+const fHeaderTestRoute: FastifyRoute<HeaderTestEndpointDef> = {
+  ...headerTestRoute,
+  controller: headerTestController,
+};
+routes.push(fHeaderTestRoute);
+
+const fInternalErrorTestRoute: FastifyRoute<InternalErrorTestEndpointDef> = {
+  ...internalErrorTestRoute,
+  controller: internalErrorTestController,
+};
+routes.push(fInternalErrorTestRoute);
+
+addRoutes(app, routes);
+
+export const internalServerErrorBody: MyApiDefaultErrorType['body'] = {
+  msg: 'Internal server error',
+};
+
+app.register(
+  typesafeApiErrors<MyApiDefaultErrorType>({
+    internalServerErrorBody,
+  })
+);
+
+export const startApp = async (): Promise<{
+  server: FastifyInstance;
+  baseUrl: string;
+}> => {
+  const [port] = await findFreePorts();
+  const baseUrl = `http://localhost:${port}`;
+
+  await app.listen({ port });
+
+  return {
+    server: app,
+    baseUrl,
+  };
+};

--- a/packages/fastify/test/ts-type.test.ts
+++ b/packages/fastify/test/ts-type.test.ts
@@ -1,0 +1,6 @@
+import { runTests } from '@typesafe-api/ts-type-test';
+
+it('ts-type-test', async () => {
+  const { expected, actual } = await runTests(__dirname + '/../');
+  expect(expected).toEqual(actual);
+}, 30000);

--- a/packages/fastify/tsconfig.json
+++ b/packages/fastify/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/fastify/tsconfig.lib.json
+++ b/packages/fastify/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/packages/fastify/tsconfig.spec.json
+++ b/packages/fastify/tsconfig.spec.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "moduleResolution": "node10",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts",
+    "__ts_type_test__/**/*.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -19,6 +19,7 @@
     "paths": {
       "@typesafe-api/core": ["packages/core/src/index.ts"],
       "@typesafe-api/express": ["packages/express/src/index.ts"],
+      "@typesafe-api/fastify": ["packages/fastify/src/index.ts"],
       "@typesafe-api/open-api": ["packages/open-api/src/index.ts"],
       "@typesafe-api/serverless": ["packages/serverless/src/index.ts"],
       "@typesafe-api/ts-type-test": ["packages/ts-type-test/src/index.ts"],


### PR DESCRIPTION
## Summary
- integrate Fastify with typesafe-api
- provide Fastify error middleware and route helpers
- configure tsconfig path and workspace project
- include tests and type tests for the new package

## Testing
- `npx nx run-many --target=test --all` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841a3c647408321a36dabc78c9cee90